### PR TITLE
Detecting unexpected bugs

### DIFF
--- a/tests/cargo_test.ts
+++ b/tests/cargo_test.ts
@@ -4,7 +4,7 @@ import {
   Chain,
   Account,
   types,
-} from "https://deno.land/x/clarinet@v0.14.0/index.ts";
+} from "https://deno.land/x/clarinet@v0.31.0/index.ts";
 import { assertEquals } from "https://deno.land/std@0.90.0/testing/asserts.ts";
 
 Clarinet.test({
@@ -245,4 +245,27 @@ Clarinet.test({
       `(ok {location: "Denver", receiver: ${receiver}, shipper: ${shipper}, status: "In Transit"})`
     );
   },
+});
+
+import fc
+  from 'https://cdn.skypack.dev/fast-check@3.0.0';
+
+import { CargoCommands }
+  from './model-based/CargoCommands.ts'
+
+Clarinet.test({
+  name: 'Cargo V1 generated tests',
+  async fn(chain: Chain, accounts: Map<string, Account>) {
+    const initialChain = { chain: chain };
+    const initialModel = {
+      shipments: new Map<number, Record<string, string>>(),
+      currentId: 0
+    };
+    fc.assert(fc.property(
+      CargoCommands(accounts), (cmds: []) => {
+        const initialState = () =>
+          ({ model: initialModel, real: initialChain });
+        fc.modelRun(initialState, cmds);
+    }), { numRuns: 10, verbose: true });
+  }
 });

--- a/tests/model-based/CargoCommandModel.ts
+++ b/tests/model-based/CargoCommandModel.ts
@@ -1,0 +1,53 @@
+// @ts-nocheck
+// https://github.com/dubzzz/fast-check/issues/2781
+
+import { Chain, types }
+  from 'https://deno.land/x/clarinet@v0.31.0/index.ts';
+
+export class Principal {
+  readonly value: string;
+
+  constructor(value: string) {
+    this.value = value;
+  }
+
+  clarityValue(): string {
+    return types.principal(this.value);
+  }
+}
+
+export class Uint {
+  readonly value: number;
+
+  constructor(value: number) {
+    this.value = value;
+  }
+
+  clarityValue(): string {
+    return types.uint(this.value);
+  }
+}
+
+export class Ascii {
+  readonly value: string;
+
+  constructor(value: string) {
+    this.value = value;
+  }
+
+  clarityValue(): string {
+    return types.ascii(this.value);
+  }
+}
+
+export type Model = {
+  shipments: Map<number, Record<string, string>>
+, currentId: number
+};
+
+export type Real = {
+  chain: Chain
+};
+
+export type CargoCommand =
+  fc.Command<Model, Real>;

--- a/tests/model-based/CargoCommands.ts
+++ b/tests/model-based/CargoCommands.ts
@@ -1,0 +1,93 @@
+// @ts-nocheck
+// https://github.com/dubzzz/fast-check/issues/2781
+
+import { Account }
+  from 'https://deno.land/x/clarinet@v0.31.0/index.ts';
+
+import fc
+  from 'https://cdn.skypack.dev/fast-check@3.0.0';
+
+import { Principal, Uint, Ascii }
+  from './CargoCommandModel.ts'
+
+import { CargoCreateShipmentCommand }
+  from './CargoCreateShipmentCommand.ts'
+
+import { CargoGetShipmentCommand }
+  from './CargoGetShipmentCommand.ts'
+
+import { CargoGetUnknownShipmentCommand }
+  from './CargoGetUnknownShipmentCommand.ts'
+
+import { CargoUpdateShipmentCommand }
+  from './CargoUpdateShipmentCommand.ts'
+
+import { CargoUpdateOthersShipmentCommand }
+  from './CargoUpdateOthersShipmentCommand.ts'
+
+export function CargoCommands(accounts: Map<string, Account>) {
+  const allCommands = [
+    fc.record({
+        region: fc.constantFrom('Southwest', 'Southeast', 'Midwest')
+      , sender: fc.constantFrom(...accounts.values()).map(account => account.address)
+      , giftee: fc.constantFrom(...accounts.values()).map(account => account.address)
+    }).map(r =>
+      new CargoCreateShipmentCommand(
+          new Ascii(
+            r.region)
+        , new Principal(
+            r.sender)
+        , new Principal(
+            r.giftee)
+        )
+      ),
+    fc.record({
+        shipId: fc.integer({min: 1, max: 100})
+    }).map(r =>
+      new CargoGetShipmentCommand(
+          new Uint(
+            r.shipId)
+        )
+      ),
+    fc.record({
+        shipId: fc.integer({min: 100, max: 999})
+      , sender: fc.constantFrom(...accounts.values()).map(account => account.address)
+    }).map(r =>
+      new CargoGetUnknownShipmentCommand(
+          new Uint(
+            r.shipId)
+        , new Principal(
+            r.sender)
+        )
+      ),
+    fc.record({
+        shipId: fc.integer({min: 1, max: 100}),
+        region: fc.constantFrom('Northeast', 'West')
+      , sender: fc.constantFrom(...accounts.values()).map(account => account.address)
+    }).map(r =>
+      new CargoUpdateShipmentCommand(
+          new Uint(
+            r.shipId)
+        , new Ascii(
+            r.region)
+        , new Principal(
+            r.sender)
+        )
+      ),
+    fc.record({
+        shipId: fc.integer({min: 1, max: 100}),
+        region: fc.constantFrom('Northeast', 'West')
+      , sender: fc.constantFrom(...accounts.values()).map(account => account.address)
+    }).map(r =>
+      new CargoUpdateOthersShipmentCommand(
+          new Uint(
+            r.shipId)
+        , new Ascii(
+            r.region)
+        , new Principal(
+            r.sender)
+        )
+      ),
+  ];
+  return fc.commands(allCommands, { size: '+1' });
+}

--- a/tests/model-based/CargoCreateShipmentCommand.ts
+++ b/tests/model-based/CargoCreateShipmentCommand.ts
@@ -1,0 +1,78 @@
+// @ts-nocheck
+// https://github.com/dubzzz/fast-check/issues/2781
+
+import { Tx }
+  from 'https://deno.land/x/clarinet@v0.31.0/index.ts';
+
+import { Principal, Ascii, Model, Real, CargoCommand }
+  from './CargoCommandModel.ts'
+
+export class CargoCreateShipmentCommand
+  implements CargoCommand {
+
+  readonly region: Ascii;
+  readonly sender: Principal;
+  readonly giftee: Principal;
+
+  constructor(
+      region: Ascii
+    , sender: Principal
+    , giftee: Principal
+    ) {
+    this.region = region;
+    this.sender = sender;
+    this.giftee = giftee;
+  }
+
+  check(_: Readonly<Model>): bool {
+    // Can always create shipment.
+    return true;
+  }
+
+  run(model: Model, real: Real): void {
+    const block = real.chain.mineBlock([
+      Tx.contractCall(
+          'cargo'
+        , 'create-new-shipment'
+        , [ this.region.clarityValue()
+          , this.giftee.clarityValue() ]
+        , this.sender.value
+      )
+    ]);
+    block
+      .receipts[0]
+      .result
+      .expectOk()
+      .expectAscii(
+        'Shipment created successfully');
+
+    model.currentId = model.currentId + 1;
+    model.shipments[model.currentId] = {
+        region: this.region
+                  .clarityValue()
+      , status: new Ascii('In Transit')
+                  .clarityValue()
+      , sender: this.sender
+                  .value
+      , giftee: this.giftee
+                  .value
+    };
+
+    console.log(this.printInfo(model));
+  }
+
+  toString() {
+    // fast-check will call toString() in case of errors, e.g. property failed.
+    // It will then make a minimal counterexample, a process called 'shrinking'
+    // https://github.com/dubzzz/fast-check/issues/2864#issuecomment-1098002642
+    return `tx-sender ${this.sender.value} create-new-shipment`;
+  }
+
+  printInfo(model: Readonly<Model>) {
+    const info =
+        `Ӿ tx-sender ${this.sender.value.padStart(43, ' ')} `
+      + `✓ create-new-shipment id ${model.currentId.toString().padStart(3, ' ')} `
+      + `${this.region.clarityValue()}`;
+    return info;
+  }
+}

--- a/tests/model-based/CargoGetShipmentCommand.ts
+++ b/tests/model-based/CargoGetShipmentCommand.ts
@@ -1,0 +1,61 @@
+// @ts-nocheck
+// https://github.com/dubzzz/fast-check/issues/2781
+
+import { Uint, Model, Real, CargoCommand }
+  from './CargoCommandModel.ts'
+
+import { assertEquals }
+  from 'https://deno.land/std@0.90.0/testing/asserts.ts';
+
+export class CargoGetShipmentCommand
+  implements CargoCommand {
+
+  readonly shipId: Uint;
+
+  constructor(
+      shipId: Uint
+    ) {
+    this.shipId = shipId;
+  }
+
+  check(model: Readonly<Model>): bool {
+    const hasShipped = this.shipId.value < model.currentId;
+    return hasShipped;
+  }
+
+  run(model: Model, real: Real): void {
+    const record = model.shipments[this.shipId.value];
+    const actual = real.chain
+      .callReadOnlyFn(
+        'cargo', 'get-shipment', [this.shipId.clarityValue()],
+        record.sender)
+      .result
+      .expectOk()
+      .expectTuple();
+
+    assertEquals(actual, {
+      location: record.region,
+      receiver: record.giftee,
+      shipper : record.sender,
+      status  : record.status
+    });
+
+    console.log(this.printInfo(model));
+  }
+
+  toString() {
+    // fast-check will call toString() in case of errors, e.g. property failed.
+    // It will then make a minimal counterexample, a process called 'shrinking'
+    // https://github.com/dubzzz/fast-check/issues/2864#issuecomment-1098002642
+    return `get-shipment ${this.shipId.value}`;
+  }
+
+  printInfo(model: Readonly<Model>) {
+    const ship = model.shipments[this.shipId.value];
+    const info =
+        `Ӿ tx-sender ${ship.sender.padStart(43, ' ')} `
+      + `✓ ${'get-shipment'.padStart(19, ' ')} `
+      + `id ${this.shipId.value.toString().padStart(3, ' ')} ${ship.region}`;
+    return info;
+  }
+}

--- a/tests/model-based/CargoGetUnknownShipmentCommand.ts
+++ b/tests/model-based/CargoGetUnknownShipmentCommand.ts
@@ -1,0 +1,53 @@
+// @ts-nocheck
+// https://github.com/dubzzz/fast-check/issues/2781
+
+import { Principal, Uint, Model, Real, CargoCommand }
+  from './CargoCommandModel.ts'
+
+export class CargoGetUnknownShipmentCommand
+  implements CargoCommand {
+
+  readonly shipId: Uint;
+  readonly sender: Principal;
+
+  constructor(
+      shipId: Uint
+    , sender: Principal
+    ) {
+    this.shipId = shipId;
+    this.sender = sender;
+  }
+
+  check(model: Readonly<Model>): bool {
+    const isUnknown = this.shipId.value > model.currentId;
+    return isUnknown;
+  }
+
+  run(_: Model, real: Real): void {
+    real.chain
+      .callReadOnlyFn(
+        'cargo', 'get-shipment', [this.shipId.clarityValue()],
+        this.sender.value)
+      .result
+      .expectErr()
+      .expectUint(100);
+
+    console.log(this.printInfo());
+  }
+
+  toString() {
+    // fast-check will call toString() in case of errors, e.g. property failed.
+    // It will then make a minimal counterexample, a process called 'shrinking'
+    // https://github.com/dubzzz/fast-check/issues/2864#issuecomment-1098002642
+    return `get-shipment ${this.shipId.value} (which is unknown)`;
+  }
+
+  printInfo(_: Readonly<Model>) {
+    const info =
+        `Ӿ tx-sender ${this.sender.value.padStart(43, ' ')} `
+      + `░ ${'get-shipment'.padStart(19, ' ')} `
+      + `id ${this.shipId.value.toString().padStart(3, ' ')} `
+      + `which is unknown, returns err u100`;
+    return info;
+  }
+}

--- a/tests/model-based/CargoUpdateOthersShipmentCommand.ts
+++ b/tests/model-based/CargoUpdateOthersShipmentCommand.ts
@@ -1,0 +1,69 @@
+// @ts-nocheck
+// https://github.com/dubzzz/fast-check/issues/2781
+
+import { Tx }
+  from 'https://deno.land/x/clarinet@v0.31.0/index.ts';
+
+import { Principal, Ascii, Model, Real, CargoCommand }
+  from './CargoCommandModel.ts'
+
+export class CargoUpdateOthersShipmentCommand
+  implements CargoCommand {
+
+  readonly shipId: Uint;
+  readonly region: Ascii;
+  readonly sender: Principal;
+
+  constructor(
+      shipId: Uint
+    , region: Ascii
+    , sender: Principal
+    ) {
+    this.shipId = shipId;
+    this.region = region;
+    this.sender = sender;
+  }
+
+  check(model: Readonly<Model>): bool {
+    const hasShipped = this.shipId.value < model.currentId;
+    if (hasShipped) {
+      const shipment = model.shipments[this.shipId.value];
+      return shipment.sender !== this.sender.value; // Other sender's shipment.
+    }
+    return false;
+  }
+
+  run(model: Model, real: Real): void {
+    const block = real.chain.mineBlock([
+      Tx.contractCall(
+          'cargo'
+        , 'update-shipment'
+        , [ this.shipId.clarityValue()
+          , this.region.clarityValue() ]
+        , this.sender.value
+      )
+    ]);
+    block
+      .receipts[0]
+      .result
+      .expectErr()
+      .expectUint(101);
+
+    console.log(this.printInfo(model));
+  }
+
+  toString() {
+    // fast-check will call toString() in case of errors, e.g. property failed.
+    // It will then make a minimal counterexample, a process called 'shrinking'
+    // https://github.com/dubzzz/fast-check/issues/2864#issuecomment-1098002642
+    return `tx-sender ${this.sender.value} update-shipment`;
+  }
+
+  printInfo(_: Readonly<Model>) {
+    const info =
+        `Ӿ tx-sender ${this.sender.value.padStart(43, ' ')} `
+      + `░     update-shipment id ${this.shipId.value.toString().padStart(3, ' ')} `
+      + `which belogs to others, returns err u101`;
+    return info;
+  }
+}

--- a/tests/model-based/CargoUpdateShipmentCommand.ts
+++ b/tests/model-based/CargoUpdateShipmentCommand.ts
@@ -1,0 +1,72 @@
+// @ts-nocheck
+// https://github.com/dubzzz/fast-check/issues/2781
+
+import { Tx }
+  from 'https://deno.land/x/clarinet@v0.31.0/index.ts';
+
+import { Principal, Ascii, Model, Real, CargoCommand }
+  from './CargoCommandModel.ts'
+
+export class CargoUpdateShipmentCommand
+  implements CargoCommand {
+
+  readonly shipId: Uint;
+  readonly region: Ascii;
+  readonly sender: Principal;
+
+  constructor(
+      shipId: Uint
+    , region: Ascii
+    , sender: Principal
+    ) {
+    this.shipId = shipId;
+    this.region = region;
+    this.sender = sender;
+  }
+
+  check(model: Readonly<Model>): bool {
+    const hasShipped = this.shipId.value < model.currentId;
+    if (hasShipped) {
+      const shipment = model.shipments[this.shipId.value];
+      return shipment.sender === this.sender.value;
+    }
+    return false;
+  }
+
+  run(model: Model, real: Real): void {
+    const block = real.chain.mineBlock([
+      Tx.contractCall(
+          'cargo'
+        , 'update-shipment'
+        , [ this.shipId.clarityValue()
+          , this.region.clarityValue() ]
+        , this.sender.value
+      )
+    ]);
+    block
+      .receipts[0]
+      .result
+      .expectOk()
+      .expectAscii(
+        'Shipment updated successfully');
+
+    model.shipments[this.shipId.value].region = this.region.clarityValue();
+
+    console.log(this.printInfo(model));
+  }
+
+  toString() {
+    // fast-check will call toString() in case of errors, e.g. property failed.
+    // It will then make a minimal counterexample, a process called 'shrinking'
+    // https://github.com/dubzzz/fast-check/issues/2864#issuecomment-1098002642
+    return `tx-sender ${this.sender.value} update-shipment`;
+  }
+
+  printInfo(model: Readonly<Model>) {
+    const info =
+        `Ӿ tx-sender ${this.sender.value.padStart(43, ' ')} `
+      + `✓     update-shipment id ${model.currentId.toString().padStart(3, ' ')} `
+      + `${this.region.clarityValue()}`;
+    return info;
+  }
+}


### PR DESCRIPTION
@kenrogers, here's a PR the can help detect unexpected bugs, as described in [Clarity model-based testing primer](https://blog.nikosbaxevanis.com/2022/03/15/clarity-clarity-model-based-testing-primer) ([tl;dr](https://blog.nikosbaxevanis.com/2022/03/15/clarity-clarity-model-based-testing-primer/#summary)):

* Define one or more commands for each one of the public functions of the cargo contract.
  * Pick zero, one or more commands and run them sequentially if they can be executed on the current state.
* Define a TypeScript model, as a simplified version of the cargo contract. Commands can then check for potential problems or inconsistencies between the model and the contract.

Sample output:

![image](https://user-images.githubusercontent.com/287532/164042854-66b780a4-fdcf-4147-861e-0ece51a4c1f1.png)

**NOTE 1**: This is *not* meant to replace the existing tests. The existing tests are [example-based](https://fsharpforfunandprofit.com/posts/property-based-testing-1/#combining-property-based-tests-with-example-based-tests) and can serve as API documentation. The generated ones are for *detecting the unexpected* as in the [paper](https://www.cs.tufts.edu/~nr/cs257/archive/john-hughes/quviq-testing.pdf), [talk](https://www.youtube.com/watch?v=hXnS_Xjwk2Y), [post](https://medium.com/criteo-engineering/detecting-the-unexpected-in-web-ui-fuzzing-1f3822c8a3a5). We need both types of tests.

**NOTE 2**: The generators I am using in this PR are constant (vs linear, exponential, etc) and the distribution of the generated data is not thoroughly thought through. If I was testing Arkadiko, or Alex, I would have tweaked those and more.

**NOTE 3**: If a command fails, a minimal counterexample is printed, a process called *shrinking*:

```
* Cargo V1 generated tests ... FAILED (596ms)

failures:

Cargo V1 generated tests
Error: Property failed after 3 tests
{ seed: 68306795, path: "2:1:0", endOnFailure: true }
Counterexample: [get-shipment 1 /*replayPath="DCBDABMADABCZB:qqC"*/]
Shrunk 2 time(s)
Got error: AssertionError: Values are not equal:

    [Diff] Actual / Expected

    {
      location: '"Southwest"',
-     receiver: "ST2NEB84ASENDXKYGJPQW86YXQCEFEX2ZQPG87ND",
-     shipper: "ST2NEB84ASENDXKYGJPQW86YXQCEFEX2ZQPG87ND",
+     receiver: "ST3PF13W7Z0RRM42A8VZRVFQ75SV1K26RXEP8YGKJ",
+     shipper: "ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5",
      status: '"In Transit"',
    }

Encountered failures were:
- [get-shipment 848 (which is unknown)
  ,tx-sender ST2NEB84ASENDXKYGJPQW86YXQCEFEX2ZQPG87ND create-new-shipment
  ,tx-sender ST2NEB84ASENDXKYGJPQW86YXQCEFEX2ZQPG87ND create-new-shipment
  ,tx-sender ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG create-new-shipment
  ,get-shipment 476 (which is unknown)
  ,tx-sender ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG create-new-shipment
  ,get-shipment 284 (which is unknown)
  ,tx-sender ST3NBRSFKX28FQ2ZJ1MAKX58HKHSDGNV5N7R21XCP create-new-shipment
  ,get-shipment 496 (which is unknown)
  ,get-shipment 430 (which is unknown)
  ,get-shipment 820 (which is unknown)
  ,get-shipment 224 (which is unknown)
  ,tx-sender ST2NEB84ASENDXKYGJPQW86YXQCEFEX2ZQPG87ND create-new-shipment
  ,get-shipment 13
    /*replayPath="DCBDABMADABCZB:qqC"*/]
- [get-shipment 13
    /*replayPath="DCBDABMADABCZB:qqC"*/]
- [get-shipment 1
    /*replayPath="DCBDABMADABCZB:qqC"*/]
```
